### PR TITLE
Update hyprland-colors.conf and starship.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 #### List of all templates
 - [Hyprland](#hyprland)
+- [Hyprlock](#hyprlock)
 - [Waybar](#waybar)
 - [Kitty](#kitty)
 - [GTK (3.0, 4.0)](#gtk)
@@ -44,14 +45,42 @@ input_path = 'path/to/template'
 output_path = '~/.config/hypr/colors.conf'
 ```
 
-Then, add this line to the top of your `~/.config/hypr/config.conf` file
+Then, add this line to the top of your `~/.config/hypr/hyprland.conf` file
 ```
-source = ~/.config/hypr/colors.conf
+source = colors.conf
 ```
 
 The theme will now be applied after you reload hyprland.
 > [!NOTE]
 > To reload hyprland you can either quit the current session and enter it again, or you can run `hyprctl reload` which instantly reloads your config.
+
+### Hyprlock
+Hyprlock uses the same color format as Hyprland so we can use `hyprland-colors.css`, if you didn't make the template above, Copy the [hyprland-colors.conf]() template and add it to the matugen config.
+```toml
+[config]
+# ...
+
+[templates.hyprland]
+input_path = 'path/to/template'
+output_path = '~/.config/hypr/colors.conf'
+```
+
+Then, add this line to the top of your `~/.config/hypr/hyprlock.conf` file
+```
+source = colors.conf
+```
+
+Configuration Example (`hyprlock.conf`):
+```
+source = colors.conf
+background {
+    path = $image  # This variable contains the image you selected with matugen     
+}
+
+label {
+    color = $primary
+}
+```
 
 ### Waybar
 Copy the [colors.css](https://github.com/InioX/matugen-themes/blob/main/templates/colors.css) template and add it to the matugen config.

--- a/templates/hyprland-colors.conf
+++ b/templates/hyprland-colors.conf
@@ -1,3 +1,4 @@
 <* for name, value in colors *>
+$image = {{image}}
 ${{name}} = rgba({{value.default.hex_stripped}}ff)
 <* endfor *>

--- a/templates/hyprland-colors.conf
+++ b/templates/hyprland-colors.conf
@@ -1,8 +1,3 @@
-general {
-    col.active_border = {{colors.primary_fixed.default.rgba}}
-    col.inactive_border = {{colors.secondary_fixed_dim.default.rgba}}
-}
-
-misc {
-    background_color = {{colors.surface.default.rgba}}
-}
+<* for name, value in colors *>
+${{name}} = rgba({{value.default.hex_stripped}}ff)
+<* endfor *>

--- a/templates/starship-colors.toml
+++ b/templates/starship-colors.toml
@@ -1,18 +1,46 @@
-format="""$directory$git_branch
-$character"""
-add_newline = true
+format = '''
+$directory$git_branch$rust$python
+$character'''
+
+palette = 'colors'
+
+[palettes.colors]
+mustard = '#af8700' # example
+color1 = '{{colors.primary_fixed_dim.default.hex}}'
+color2 = '{{colors.on_primary.default.hex}}'
+color3 = '{{colors.on_surface_variant.default.hex}}'
+color4 = '{{colors.surface_container.default.hex}}'
+color5 = '{{colors.on_primary.default.hex}}'
+color6 = '{{colors.surface_dim.default.hex}}'
+color7 = '{{colors.surface.default.hex}}'
+color8 = '{{colors.primary.default.hex}}'
+color9 = '{{colors.tertiary.default.hex}}'
 
 # Prompt symbols 
-# [character]
-# success_symbol = "({{colors.tertiary.default.hex}} bold)"
-# error_symbol = "(@{error})"
-# vicmd_symbol = "(#f9e2af)"
+[character]
+success_symbol = "[🞈](color9 bold)"
+error_symbol = "[🞈](@{error})"
+vicmd_symbol = "[🞈](#f9e2af)"
 
 [directory]
-format = """
-[]($style)[$path](fg:{{colors.on_primary.default.hex}} bg:{{colors.primary.default.hex}})[ ](fg:{{colors.primary.default.hex}})"""
+format = "[](fg:color1 bg:color4)[󰉋](bg:color1 fg:color2)[ ](fg:color1 bg:color4)[$path ](fg:color3 bg:color4)[ ](fg:color4)"
 
-style = "fg:{{colors.primary.default.hex}}"
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
 
 [git_branch]
-style = "fg:{{colors.primary.default.hex}}"
+format = "[](fg:color8 bg:color4)[ ](bg:color8 fg:color5)[](fg:color8 bg:color4)[(bg:color8 fg:color5) $branch](fg:color3 bg:color4)[](fg:color4) "
+
+[time]
+format = "[](fg:color8 bg:color4)[ ](bg:color8 fg:color5)[](fg:color8 bg:color4)[(bg:color8 fg:color5) $time](fg:color3 bg:color4)[](fg:color4) "
+disabled = false
+time_format = "%R" # Hour:Minute Format
+
+[python]
+format = "[](fg:color8 bg:color4)[${symbol}${version}](bg:color8 fg:color5)[](fg:color8 bg:color4)[(bg:color8 fg:color5)( ${virtualenv})](fg:color3 bg:color4)[](fg:color4) "
+symbol = '🐍'
+# pyenv_version_name = true
+pyenv_prefix = 'venv'


### PR DESCRIPTION
hyprland colors work correctly now, I don't know why it uses this weird rgba comma-less format. I updated the starship theme to use the palette system as well and added support for showing the python venv

preview:
![image](https://github.com/user-attachments/assets/96cf59de-31cf-4bf4-8ee2-d45550b7076c)
![image](https://github.com/user-attachments/assets/887fb267-c3e8-4fda-b2fb-21f81f29272e)
![image](https://github.com/user-attachments/assets/1d877e78-6004-4007-bcf3-39f36c63272f)
There is still the black square behind the blue circle appearing, but I haven't figured out how to solve it