### PR TITLE
feat(docs): add the rest of the hooks that were removed upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Copy the [kitty-colors.conf](https://github.com/InioX/matugen-themes/blob/main/t
 [templates.kitty]
 input_path = 'path/to/template'
 output_path = '~/.config/kitty/colors.conf'
+post_hook = 'pkill -SIGUSR1 kitty'
 ```
 
 Then, add this line to the bottom of your `~/.config/kitty/kitty.conf`
@@ -133,6 +134,7 @@ The theme will now be applied after you reload kitty.
 [templates.gtk3]
 input_path = 'path/to/template'
 output_path = '~/.config/gtk-3.0/colors.css'
+post_hook = 'gsettings set org.gnome.desktop.interface gtk-theme ""; gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-{{mode}}'
 
 [templates.gtk4]
 input_path = 'path/to/template'
@@ -210,6 +212,7 @@ You can now use all the color variables inside of the `config.rasi`.
 [templates.dunst]
 input_path = 'path/to/template'
 output_path = '~/.config/dunst/dunstrc'
+post_hook = 'pkill -SIGUSR2 dunst
 ```
 
 ### qt


### PR DESCRIPTION
Closes #5
A hook for mako is missing
  - There isn't an existing mako template and it wouldn't make sense to add a hook for a program that doesn't have a template
  - I don't know which colors should go where so I can't really make a mako template myself
  - It looks like the only repo where mako is being used with matugen(at least publicly and on github) is [this](https://github.com/sherryhock/dotfiles/blob/master/dot_config/matugen/templates/mako/config), but it doesn't have a license. On that note, you should add the MIT license to this project so people can copy things


Also, how would I access args.mode in a `post_hook` to replicate this old code?

<details>
<summary>old code in reload/unix.rs</summary>

```rust
fn reload_gtk_theme(args: &Cli) -> Result<(), Report> {
    let mode = match args.mode {
        Some(SchemesEnum::Light) => "light",
        Some(SchemesEnum::Dark) => "dark",
        None => "dark",
    };
    set_theme("")?;
    set_theme(format!("adw-gtk3-{}", mode).as_str())?;
    Ok(())
}

fn set_theme(theme: &str) -> Result<(), Report> {
    Command::new("gsettings")
        .args(["set", "org.gnome.desktop.interface", "gtk-theme", theme])
        .spawn()?;
    Ok(())
}
```