### PR TITLE
feat: add a nix flake and a home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@
 - [Midnight-Discord](#midnight-discord)
 
 ### Hyprland
-Copy the [hyprland-colors.conf]() template and add it to the matugen config.
+Copy the [hyprland-colors.conf](./templates/hyprland-colors.conf) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.hyprland]
-input_path = 'path/to/template'
+input_path = './templates/hyprland-colors.conf'
 output_path = '~/.config/hypr/colors.conf'
 post_hook = 'hyprctl reload'
 ```
@@ -56,13 +56,13 @@ The theme will now be applied after you reload hyprland.
 > To reload hyprland you can either quit the current session and enter it again, or you can run `hyprctl reload` which instantly reloads your config.
 
 ### Hyprlock
-Hyprlock uses the same color format as Hyprland so we can use `hyprland-colors.css`, if you didn't make the template above, Copy the [hyprland-colors.conf]() template and add it to the matugen config.
+Hyprlock uses the same color format as Hyprland so we can use the same template. If you didn't use the template above, copy the [hyprland-colors.conf](./templates/hyprland-colors.conf) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
-[templates.hyprland]
-input_path = 'path/to/template'
+[templates.hyprlock]
+input_path = './templates/hyprland-colors.conf'
 output_path = '~/.config/hypr/colors.conf'
 ```
 
@@ -71,7 +71,7 @@ Then, add this line to the top of your `~/.config/hypr/hyprlock.conf` file
 source = colors.conf
 ```
 
-Configuration Example (`hyprlock.conf`):
+Configuration example (`hyprlock.conf`):
 ```
 source = colors.conf
 background {
@@ -84,13 +84,13 @@ label {
 ```
 
 ### Waybar
-Copy the [colors.css](https://github.com/InioX/matugen-themes/blob/main/templates/colors.css) template and add it to the matugen config.
+Copy the [colors.css](./templates/colors.css) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.waybar]
-input_path = 'path/to/template'
+input_path = './templates/colors.css'
 output_path = '~/.config/waybar/colors.css'
 post_hook = 'pkill -SIGUSR2 waybar'
 ```
@@ -108,13 +108,13 @@ You can now use all the color variables inside the file.
 ```
 
 ### Kitty
-Copy the [kitty-colors.conf](https://github.com/InioX/matugen-themes/blob/main/templates/kitty-colors.conf) template and add it to the matugen config.
+Copy the [kitty-colors.conf](./templates/kitty-colors.conf) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.kitty]
-input_path = 'path/to/template'
+input_path = './templates/kitty-colors.conf'
 output_path = '~/.config/kitty/colors.conf'
 ```
 
@@ -126,31 +126,33 @@ include colors.conf
 The theme will now be applied after you reload kitty.
 
 ### GTK
+Copy the [gtk-colors.css](./templates/gtk-colors.css) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.gtk3]
-input_path = 'path/to/template'
+input_path = './templates/gtk-colors.css'
 output_path = '~/.config/gtk-3.0/colors.css'
 
 [templates.gtk4]
-input_path = 'path/to/template'
+input_path = './templates/gtk-colors.css'
 output_path = '~/.config/gtk-4.0/colors.css'
 ```
 
-Then, add this line to the top of your `~/.config/gtk-3.0/gtk.css` and `~/.config/gtk-4.0/gtk.css`
+Then, add this line to the top of `~/.config/gtk-3.0/gtk.css` and `~/.config/gtk-4.0/gtk.css`
 ```css
 @import 'colors.css';
 ```
 
 ### Sway
+Copy the [sway-colors.conf](./templates/sway-colors.conf) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.sway]
-input_path = 'path/to/template'
+input_path = './templates/sway-colors.conf'
 output_path = '~/.config/sway/colors.conf'
 post_hook = 'swaymsg reload'
 ```
@@ -161,12 +163,13 @@ include colors.conf
 ```
 
 ### wlogout
+Copy the [colors.css](./templates/colors.css) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 # ...
 
 [templates.wlogout]
-input_path = 'path/to/template'
+input_path = './templates/colors.css'
 output_path = '~/.config/wlogout/colors.css'
 ```
 
@@ -183,11 +186,12 @@ You can now use all the color variables inside the file.
 ```
 
 ### Rofi
+Copy the [rofi-colors.rasi](./templates/rofi-colors.rasi) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 
 [templates.rofi]
-input_path = 'path/to/template'
+input_path = './templates/rofi-colors.rasi'
 output_path = '~/.config/rofi/colors.rasi'
 ```
 
@@ -204,21 +208,23 @@ You can now use all the color variables inside of the `config.rasi`.
 ```
 
 ### dunst
+Copy the [dunstrc-colors](./templates/dunstrc-colors) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 
 [templates.dunst]
-input_path = 'path/to/template'
+input_path = './templates/dunstrc-colors'
 output_path = '~/.config/dunst/dunstrc'
 ```
 
 ### qt
+Copy the [qtct-colors](./templates/qtct-colors) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 Change `5` to `6` for qt6ct
 ```toml
 [config]
 
 [templates.qt5ct]
-input_path = 'path/to/template'
+input_path = './templates/qtct-colors.conf'
 output_path = '~/.config/qt5ct/colors/matugen.conf'
 ```
 Then, add these two lines to the top of your `~/.config/qt5ct/qt5ct.conf`
@@ -229,11 +235,12 @@ custom_palette=true
 ```
 
 ### Alacritty
+Copy the [alacritty.toml](./templates/alacritty.toml) template to `$XDG_CONFIG_HOME/matugen/templates/`.
 ```toml
 [config]
 
 [templates.alacritty]
-input_path = 'path/to/template'
+input_path = './templates/alacritty.toml'
 output_path = '~/.config/alacritty/colors.toml'
 ```
 Then, add this line to your `~/.config/alacritty/alacritty.toml`
@@ -242,23 +249,27 @@ import = ["colors.toml"]
 ```
 
 ### Starship
+Copy the [starship-colors.toml](./templates/starship-colors.toml) template to `$XDG_CONFIG_HOME/matugen/templates/`(with your own modifications).
 ```toml
 [config]
 
 [templates.starship]
-input_path = 'path/to/template'
+input_path = './templates/starship-colors.toml'
 output_path = '~/.config/starship.toml'
 ```
+> [!WARNING]
+> This will overwrite `~/.config/starship.toml.` Please modify the template to your liking before adding it to your matugen configuration
+
 That's it!
 
 
 <h2 class="acknowledgements">
-     <sub>
-          <img  src="https://github.com/InioX/dotfiles/assets/81521595/353caef1-d2bd-4a10-a709-c64b35465e65"
-           height="25"
-           width="25">
-     </sub>
-     Acknowledgements
+    <sub>
+        <img src="https://github.com/InioX/dotfiles/assets/81521595/353caef1-d2bd-4a10-a709-c64b35465e65"
+        height="25"
+        width="25">
+    </sub>
+    Acknowledgements
 </h2>
 
 [Heus-Sueh](https://github.com/Heus-Sueh)

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,10 @@
+{
+  description = "Presets for matugen";
+
+  outputs = _: {
+    homeManagerModules = rec {
+      matugen-themes = import ./nix/module.nix;
+      default = matugen-themes;
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,17 @@
+{config, lib, ...}:
+let
+  inherit (config.programs.matugen-themes) presets;
+
+  templateData = import ./parseReadme.nix { inherit config lib; };
+  
+  templates = builtins.listToAttrs (map (name: lib.nameValuePair name templateData.${name}) presets);  
+in {
+  options.programs.matugen-themes.presets = with lib; mkOption {
+    type = types.listOf (types.enum (builtins.attrNames templateData));
+    default = [];
+    description = "The themes to use";
+  };
+  config = lib.mkIf (presets != []) {
+    programs.matugen.settings = { inherit templates; };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,17 +1,21 @@
-{config, lib, ...}:
-let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (config.programs.matugen-themes) presets;
 
-  templateData = import ./parseReadme.nix { inherit config lib; };
-  
-  templates = builtins.listToAttrs (map (name: lib.nameValuePair name templateData.${name}) presets);  
+  templateData = import ./parseReadme.nix {inherit config lib;};
+
+  templates = builtins.listToAttrs (map (name: lib.nameValuePair name templateData.${name}) presets);
 in {
-  options.programs.matugen-themes.presets = with lib; mkOption {
-    type = types.listOf (types.enum (builtins.attrNames templateData));
-    default = [];
-    description = "The themes to use";
-  };
+  options.programs.matugen-themes.presets = with lib;
+    mkOption {
+      type = types.listOf (types.enum (builtins.attrNames templateData));
+      default = [];
+      description = "The themes to use";
+    };
   config = lib.mkIf (presets != []) {
-    programs.matugen.settings = { inherit templates; };
+    programs.matugen.settings = {inherit templates;};
   };
 }

--- a/nix/parseReadme.nix
+++ b/nix/parseReadme.nix
@@ -41,8 +41,10 @@
         attrs
         // {
           hypr = attrs.hyprland;
-          gtk3 = attrs.gtk // {output_path = "${config.xdg.configHome}/hypr/colors.config";};
+          gtk3 = attrs.gtk // {output_path = "${config.xdg.configHome}/gtk-3.0/colors.css";};
           gtk4 = attrs.gtk;
+          # The following update is not needed since the regex should get this value anyways
+          # `// {output_path = "${config.xdg.configHome}/gtk-4.0/colors.css";}`
         })
       # Removes unusable and/or unneeded entries
       (attrs:

--- a/nix/parseReadme.nix
+++ b/nix/parseReadme.nix
@@ -1,0 +1,76 @@
+{config, lib}: let
+  contents = lib.pipe
+    ../README.md
+    [
+      builtins.readFile
+      # Splits the list into 2 parts:
+      # One before this line and one after
+      # NOTE: If you add an entry to the readme after this, please trim that line
+      # and replace the string here
+      (lib.splitString "- [Midnight-Discord](#midnight-discord)")
+      # Gets that 2nd half
+      lib.last
+      # Next 2 lines remove the acknowledgements section
+      (lib.splitString "That's it!")
+      lib.head
+      # Splits the string into a list of strings. Each string is the text
+      # within a section(e.g., the details under '### Hyprland')
+      (builtins.split "###[[:space:]]")
+      (lib.filter (line: line != "\n\n" && line != []))
+      
+      # Removes trailing newlines
+      (map (line: lib.head (builtins.match "(.*[^\n])\n*" line)))
+      # Makes a types.listOf types.attrs that looks like
+      # {
+      #   name = "foo"; 
+      #   value = {
+      #     input_path = "bar"
+      #     output_path = "baz";
+      #     post_hook = "qux";
+      #   }; 
+      # }
+      (map extractKeys)
+      # Converts it into an attr set
+      builtins.listToAttrs
+      # Renames "hyprland" to "hypr" changes gtk-related things
+      (attrs: attrs // {
+        hypr = attrs.hyprland;
+        gtk3 = attrs.gtk // { output_path = "${config.xdg.configHome}/hypr/colors.config"; };
+        gtk4 = attrs.gtk;
+      })
+      # Removes unusable and/or unneeded entries
+      (attrs: builtins.removeAttrs attrs [
+        "hyprland"
+        "hyprlock"
+        "starship" # Unusable out of the box
+        "gtk"
+      ])
+    ];
+    extractKeys = section:
+    let
+      match = key: builtins.match ".*${key} = '([^']+)'.*" section;
+      
+      input_path = lib.pipe
+        "input_path"
+        [
+          match
+          builtins.head
+          (lib.removePrefix ".")
+          (path: ../. + path)
+        ];
+      output_path = builtins.replaceStrings
+        ["~/.config"]
+        ["${config.xdg.configHome}"]
+        (builtins.head (match "output_path"));
+      post_hook = match "post_hook";
+    in {
+      name = lib.toLower (builtins.head (builtins.match "([^\n]+).*" section));
+      value =
+      if post_hook == null
+      then { inherit input_path output_path; }
+      else {
+        inherit input_path output_path;
+        post_hook = builtins.head post_hook;
+      };
+    };
+in contents

--- a/nix/parseReadme.nix
+++ b/nix/parseReadme.nix
@@ -38,15 +38,24 @@
       builtins.listToAttrs
       # Renames "hyprland" to "hypr" changes gtk-related things
       (attrs:
-        attrs
-        // {
+        attrs // {
           hypr = attrs.hyprland;
-          gtk3 = attrs.gtk // {output_path = "${config.xdg.configHome}/gtk-3.0/colors.css";};
+          gtk3 = attrs.gtk // {
+            output_path = "${config.xdg.configHome}/gtk-3.0/colors.css";
+            post_hook = lib.concatStringsSep "; " [
+              "gsettings set org.gnome.desktop.interface gtk-theme ''"
+              "gsettings set org.gnome.desktop.interface gtk-theme \"${
+                if config.gtk.theme.name != null
+                then config.gtk.theme.name
+                else "Adwaita-{{mode}}"
+              }\""
+            ];
+          };
+          # The output_path for gtk4 doesn't need to be manually set since the
+          # regex should capture it
           gtk4 = attrs.gtk;
-          # The following update is not needed since the regex should get this value anyways
-          # `// {output_path = "${config.xdg.configHome}/gtk-4.0/colors.css";}`
         })
-      # Removes unusable and/or unneeded entries
+      # Removes unusable and unneeded entries
       (attrs:
         builtins.removeAttrs attrs [
           "hyprland"


### PR DESCRIPTION
This was tested with:
- your matugen repo's flake for the rust package(shouldn't really matter though)
- my matugen repo on the `danid3v-nix-refactor` branch for the main home-manager module
- this branch for, well, stuff related to this pr lol

If you want to see the available templates (in nix at least) you can run the following (you need the `nix-command` feature and [jq](https://github.com/jqlang/jq)):
```shell
nix eval -E "import ./nix/parseReadme.nix {lib = (import <nixpkgs> {}).lib; config = { xdg.configHome = \"$HOME/.config\"; gtk.theme.name = \"hello\"; }; }" --impure --json | jq -r '.' --color-output
```

## Notes:
### hm module interface:
`programs.matugen-themes.presets` is limited to a list of strings(e.g. `[ "hypr" "gtk3" ]`). You can use the name of any template in this repo, except for 2 things that have been changed(the only hardcoded things on the nix side):
1. the `hyprland` and `hyprlock` templates were merged into a single `hypr` one
2. starship is removed since it would overwrite the settings placed by the user.
  Note: I know that the file would be overwritten if they don't home-manager. IDK if it will still happen if they use home-manager for starship in the first place
#### Up for debate
Should the option be moved to `programs.matugen.enabledPresets` or something else?

### readme parsing
`nix/parseReadme.nix` uses regexes to parse the readme. It should keep working as-is until you add an entry under midnight-discord.
<details>
<summary>Regex explanations on regex101.com</summary>

- `builtins.match ".*output_path = '([^']+)'.*" section`(line 57)
  - [link](https://regex101.com/r/PfFXNs/1)
- `builtins.match "([^\n]+).*" section`(line 75)
  - [link](https://regex101.com/r/F1QK8t/1)
</details>

### Manual work on the end-user's side
They need to know what programs are run in the `post_hook`s that they are using and place them in `programs.matugen.extraPackages`, at least after [# 68 over at matugen](https://github.com/InioX/matugen/pull/68) is merged with some variant of my suggestions
A simple `realpath $(which <cmd>)` should suffice