### PR TITLE
fix .rasi syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ output_path = '~/.config/rofi/colors.rasi'
 
 Then, add this line to the top of your `~/.config/rofi/config.rasi`
 ```
-@import "colors.rasi";
+@import "colors.rasi"
 ```
 
 You can now use all the color variables inside of the `config.rasi`.


### PR DESCRIPTION
In the readme the syntax for importing external files in rasi is wrong, the correct syntax would be

```
@import "myfile"
```

https://davatorium.github.io/rofi/current/rofi-theme.5/#multiple-file-handling