### PR TITLE
add fuzzel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [Pywalfox](#pywalfox)
 - [Yazi](#yazi)
 - [Zathura](#zathura)
+- [Fuzzel](#fuzzel)
 
 ### Hyprland
 Copy the [hyprland-colors.conf]() template and add it to the matugen config.
@@ -303,6 +304,20 @@ set recolor-lightcolor      "{{colors.on_primary.default.rgba | set_alpha: 1.0}}
 And to change the font family and size just write it to:
 ```
 set font "FiraCode Nerd Font 12"
+```
+
+### Fuzzel
+```toml
+[config]
+
+[templates.fuzzel]
+input_path = 'path/to/template'
+output_path = '~/.config/fuzzel/colors.ini'
+```
+Then, add this line to the top of your `~/.config/fuzzel/fuzzel.ini` file
+```ini
+[main]
+include = "~/.config/fuzzel/colors.ini"
 ```
 
 

--- a/templates/fuzzel.ini
+++ b/templates/fuzzel.ini
@@ -1,0 +1,15 @@
+# Fuzzel Colors
+# Generated with Matugen
+
+[colors]
+background={{colors.background.default.hex_stripped}}ff
+text={{colors.on_surface.default.hex_stripped}}ff
+prompt={{colors.secondary.default.hex_stripped}}ff
+placeholder={{colors.tertiary.default.hex_stripped}}ff
+input={{colors.primary.default.hex_stripped}}ff
+match={{colors.tertiary.default.hex_stripped}}ff
+selection={{colors.primary.default.hex_stripped}}ff
+selection-text={{colors.on_surface.default.hex_stripped}}ff
+selection-match={{colors.on_primary.default.hex_stripped}}ff
+counter={{colors.secondary.default.hex_stripped}}ff
+border={{colors.primary.default.hex_stripped}}ff


### PR DESCRIPTION
Support for [Fuzzel](https://codeberg.org/dnkl/fuzzel).

![Fuzzel screenshot with Alacritty on the background. The background color is black, while the primary one is a sort of light pink. The screenshot is pretty sloppy, with the cursor appearing, and with gibberish Fuzzel output in the background (due to Alacritty)](https://github.com/user-attachments/assets/f8a2f27a-d99b-498d-8a81-2489c2f84b96)

EDIT: Finally got a screenshot. I had to pass `--no-exit-on-keyboard-focus-loss` for that.