### PR TITLE
add television support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,18 +332,18 @@ And to change the font family and size just write it to:
 set font "FiraCode Nerd Font 12"
 ```
 
-### Fuzzel
+### Television
 ```toml
 [config]
 
-[templates.fuzzel]
-input_path = 'path/to/template'
-output_path = '~/.config/fuzzel/colors.ini'
+[templates.television]
+input_path = 'templates/television.toml'
+output_path = '~/.config/television/themes/matugen.toml'
 ```
-Then, add this line to the top of your `~/.config/fuzzel/fuzzel.ini` file
-```ini
-[main]
-include = "~/.config/fuzzel/colors.ini"
+Then, add this line to the `ui` section of your `~/.config/television/config.toml` file
+```toml
+[ui]
+theme = "matugen"
 ```
 
 ### Cava

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [Pywalfox](#pywalfox)
 - [Yazi](#yazi)
 - [Zathura](#zathura)
+- [Television](#television)
 
 ### Hyprland
 Copy the [hyprland-colors.conf]() template and add it to the matugen config.
@@ -305,6 +306,19 @@ And to change the font family and size just write it to:
 set font "FiraCode Nerd Font 12"
 ```
 
+### Television
+```toml
+[config]
+
+[templates.television]
+input_path = 'templates/television.toml'
+output_path = '~/.config/television/themes/matugen.toml'
+```
+Then, add this line to the `ui` section of your `~/.config/television/config.toml` file
+```toml
+[ui]
+theme = "matugen"
+```
 
 <h2 class="acknowledgements">
      <sub>

--- a/templates/television.toml
+++ b/templates/television.toml
@@ -1,0 +1,19 @@
+# Television Colors
+# Generated with Matugen
+
+background = '{{colors.surface.default.hex}}'
+border_fg = '{{colors.outline.default.hex}}'
+text_fg = '{{colors.on_surface.default.hex}}'
+dimmed_text_fg = '{{colors.on_surface_variant.default.hex}}'
+input_text_fg = '{{colors.secondary.default.hex}}'
+result_count_fg = '{{colors.secondary.default.hex}}'
+result_name_fg = '{{colors.on_surface.default.hex}}'
+result_line_number_fg = '{{colors.secondary.default.hex}}'
+result_value_fg = '{{colors.secondary.default.hex}}'
+selection_bg = '{{colors.primary.default.hex}}'
+selection_fg = '{{colors.on_primary.default.hex}}'
+match_fg = '{{colors.inverse_primary.default.hex}}'
+preview_title_fg = '{{colors.tertiary.default.hex}}'
+channel_mode_fg = '{{colors.tertiary.default.hex}}'
+remote_control_mode_fg = '{{colors.secondary.default.hex}}'
+send_to_channel_mode_fg = '{{colors.tertiary.default.hex}}'


### PR DESCRIPTION
Support for [Television](https://github.com/alexpasmantier/television).

![Screenshot showing Alacritty with the color palette on the left side, and Television on the right. Television is a command-line fuzzy finder.](https://github.com/user-attachments/assets/93b78fdf-5e22-434f-9052-fce878ab1af0)