### PR TITLE
Fixed midnight-discord template and added information to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - [Qt (qt5, qt6)](#qt)
 - [Alacritty](#alacritty)
 - [Starship](#starship)
-- [Midnight-Discord](#midnight-discord)
+- [Midnight Discord](#midnight-discord)
 - [Pywalfox](#pywalfox)
 - [Yazi](#yazi)
 - [Zathura](#zathura)
@@ -258,6 +258,23 @@ import = ["colors.toml"]
 input_path = 'path/to/template'
 output_path = '~/.config/starship.toml'
 ```
+
+### Midnight Discord
+
+Copy the [midnight-discord.css](https://github.com/InioX/matugen-themes/blob/main/templates/midnight-discord.css) template and add it to the matugen config.
+
+```toml
+[config]
+
+[templates.vesktop]
+input_path = 'path/to/template'
+output_path = '/home/elrond/.config/vesktop/themes/midnight-discord.css'
+```
+
+> [!NOTE]
+> ``output_path`` may be different if you are using Flatpak version of Vesktop.
+
+Then, activate the theme from vencord themes.
 
 ### Pywalfox
 ```toml

--- a/templates/midnight-discord.css
+++ b/templates/midnight-discord.css
@@ -12,7 +12,7 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+@import url('https://refact0r.github.io/midnight-discord/build/midnight.css');
 
 /* customize things here */
 :root {


### PR DESCRIPTION
import url in the template should be ``https://refact0r.github.io/midnight-discord/build/midnight.css`` 
without that theme doesn't work.

also I added a readme section for vesktop. 