### PR TITLE
Fixed yazi duplicate configs

### DIFF
--- a/templates/yazi-theme.toml
+++ b/templates/yazi-theme.toml
@@ -1,6 +1,6 @@
 # : Manager [[[
 
-[manager]
+[mgr]
 cwd = { fg = "{{colors.on_surface.default.hex}}" }
 
 # Tab


### PR DESCRIPTION
Yazi (or possibly Matugen - I'm not entirely sure which) was generating a duplicate theme configuration after Matugen ran. This PR resolves that issue, and everything works as intended.

Before the fix:
<img width="563" height="597" alt="image" src="https://github.com/user-attachments/assets/7bc6717c-ea26-48a6-b76a-d3e8cfabfa6a" />

After the fix:
No duplicates. Theme config behaves as expected.

Special thanks to [u/Z3R0_F0UR](https://www.reddit.com/user/Z3R0_F0UR/) for identifying the solution.