### PR TITLE
Fixed dunst reload 

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ You can now use all the color variables inside of the `config.rasi`.
 [templates.dunst]
 input_path = 'path/to/template'
 output_path = '~/.config/dunst/dunstrc'
-post_hook = 'pkill -SIGUSR2 dunst
+post_hook = 'dunstctl reload'
 ```
 
 ### qt


### PR DESCRIPTION
SIGUSR2 does not reload dunst (at least for me), and there already exists a simpler way to reload it