### PR TITLE
[TYPO fix] Use single quotes to wrap `cava`'s post_hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Copy the [cava-colors.ini](https://github.com/InioX/matugen-themes/blob/main/tem
 [templates.cava]
 input_path = '~/.config/matugen/templates/cava-colors.ini'
 output_path = '~/.config/cava/themes/your-theme'
-post_hook = "pkill -USR1 cava"
+post_hook = 'pkill -USR1 cava'
 ```
 
 Update the theme variable `theme = 'none'` in the cava configuration file `~/.config/cava/config` with the output_path filename.


### PR DESCRIPTION
used single quote to keep config file examples consistent

sorry 😭 (this pr may seem completely preposterous to some)