### PR TITLE
[bug fix] used correct property in mako config

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ post_hook = 'makoctl reload'
 ```
 Then, add this line to the bottom of your `~/.config/mako/config`
 ```
-import=~/.config/mako/mako-colors
+include=~/.config/mako/mako-colors
 ```
 
 ### qt


### PR DESCRIPTION
`import` is invalid syntax and will result in
```
Unable to parse configuration file (fr.emersion.Mako.InvalidConfig)
```

`include` however is the right syntax according to [wiki](https://github.com/emersion/mako/wiki/Simple-Pywal-template-integration-example)