### PR TITLE
Fix $image in loop in hyprland-colors.conf

### DIFF
--- a/templates/hyprland-colors.conf
+++ b/templates/hyprland-colors.conf
@@ -1,4 +1,4 @@
-<* for name, value in colors *>
 $image = {{image}}
+<* for name, value in colors *>
 ${{name}} = rgba({{value.default.hex_stripped}}ff)
 <* endfor *>


### PR DESCRIPTION
If not necessary, take out the $image from the loop to reduce the size of generated file and clean it.