### PR TITLE
fix kitty theme config path from theme to themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ include colors.conf
 The theme will now be applied after you reload kitty.
 
 To reload all the kitty instances automatically you can use kitty's own built-in theme manager through a kitten.
-To accomplish this we need to set the output_path of `[templates.kitty]` to `~/.config/kitty/theme/your-theme.conf`
+To accomplish this we need to set the output_path of `[templates.kitty]` to `~/.config/kitty/themes/your-theme.conf`
 
 Then append ```[templates.kitty]``` with
 ```


### PR DESCRIPTION
The user's theme folder is `~/.config/kitty/themes` instead of `.../theme`.
From the docs : https://sw.kovidgoyal.net/kitty/kittens/themes/#using-your-own-themes