### PR TITLE
fix: yazi update 25.12.29 

### DIFF
--- a/templates/yazi-theme.toml
+++ b/templates/yazi-theme.toml
@@ -3,39 +3,47 @@
 [mgr]
 cwd = { fg = "{{colors.on_surface.default.hex}}" }
 
-# Tab
-tab_active = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.primary.default.hex}}", bold = true }
-tab_inactive = { fg = "{{colors.primary_fixed.default.hex}}", bg = "{{colors.on_primary_fixed.default.hex}}" }
-tab_width = 1
-
 # Find
-find_keyword = { fg = "{{colors.error.default.hex}}", bold = true, italic = true, underline = true }
+find_keyword  = { fg = "{{colors.error.default.hex}}", bold = true, italic = true, underline = true }
 find_position = { fg = "{{colors.error.default.hex}}", bold = true, italic = true }
 
 # Marker
-marker_copied = { fg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 20.0}}", bg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 20.0}}" }
-marker_cut = { fg = "{{colors.tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
-marker_marked = { fg = "{{colors.error.default.hex}}", bg = "{{colors.error.default.hex}}" }
+marker_copied   = { fg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 20.0}}", bg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 20.0}}" }
+marker_cut      = { fg = "{{colors.tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
+marker_marked   = { fg = "{{colors.error.default.hex}}", bg = "{{colors.error.default.hex}}" }
 marker_selected = { fg = "{{colors.tertiary.default.hex}}", bg = "{{colors.tertiary.default.hex}}" }
 
 # Count
-count_copied = { fg = "{{colors.on_tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
-count_cut = { fg = "{{colors.on_tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
+count_copied   = { fg = "{{colors.on_tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
+count_cut      = { fg = "{{colors.on_tertiary_fixed.default.hex}}", bg = "{{colors.tertiary_fixed.default.hex}}" }
 count_selected = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.tertiary.default.hex}}" }
 
 # Border
-border_symbol = " "
+border_symbol = "│"
 border_style  = { fg = "{{colors.surface_tint.default.hex}}" }
 
 # : ]]]
 
 
-# : Status [[[
+# : Indicator [[[
 
-[status]
-separator_open = "🭁"
-separator_close = "🭠"
-separator_style = { bg = "{{colors.on_primary.default.hex}}", fg = "#F4A261" }
+[indicator]
+padding = { open = "█", close = "█" }
+
+# : ]]]
+
+
+# : Tabs [[[
+
+[tabs]
+active    = { fg = "{{colors.primary.default.hex}}", bold = true, bg = "{{colors.surface.default.hex}}" }
+inactive  = { fg = "{{colors.secondary.default.hex}}", bg = "{{colors.surface.default.hex}}" }
+sep_inner = { open = "[", close = "]" }
+
+# : ]]]
+
+
+# : Mode [[[
 
 [mode]
 # Mode
@@ -50,62 +58,26 @@ select_alt  = { bg = "{{colors.surface_variant.default.hex}}", fg = "{{colors.on
 unset_main = { bg = "{{colors.tertiary.default.hex}}", fg = "{{colors.on_tertiary.default.hex}}", bold = true }
 unset_alt  = { bg = "{{colors.surface_variant.default.hex}}", fg = "{{colors.on_surface_variant.default.hex}}" }
 
-# Progress
-progress_label = { bold = true }
-progress_normal = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.surface_bright.default.hex}}" }
-progress_error = { fg = "{{colors.error.default.hex}}", bg = "{{colors.surface_bright.default.hex}}" }
+# : ]]]
+
+
+# : Status [[[
+
+[status]
+sep_left  = { open = "🭁", close = "🭠" }
+sep_right = { open = "🭁", close = "🭠" }
 
 # Permissions
-permissions_t = { fg = "{{colors.secondary.default.hex | auto_lightness: 30.0}}" }
-permissions_w = { fg = "{{colors.tertiary.default.hex | auto_lightness: 30.0}}" }
-permissions_x = { fg = "{{colors.error.default.hex | auto_lightness: 30.0}}" }
-permissions_r = { fg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 30.0}}" }
-permissions_s = { fg = "{{colors.primary_fixed.default.hex | auto_lightness: 30.0}}" }
+perm_type  = { fg = "{{colors.secondary.default.hex | auto_lightness: 30.0}}" }
+perm_write = { fg = "{{colors.tertiary.default.hex | auto_lightness: 30.0}}" }
+perm_read  = { fg = "{{colors.error.default.hex | auto_lightness: 30.0}}" }
+perm_exec  = { fg = "{{colors.tertiary_fixed.default.hex | auto_lightness: 30.0}}" }
+perm_sep   = { fg = "{{colors.primary_fixed.default.hex | auto_lightness: 30.0}}" }
 
-# : ]]]
-
-
-# : Select [[[
-
-[select]
-border = { fg = "{{colors.primary.default.hex}}" }
-active = { fg = "{{colors.tertiary.default.hex}}", bold = true }
-
-# : ]]]
-
-
-# : Input [[[
-
-[input]
-border = { fg = "{{colors.primary.default.hex}}" }
-value = { fg = "{{colors.on_surface.default.hex}}" }
-
-# : ]]]
-
-# : Tabs [[[
-
-[tabs]
-active = { fg = "{{colors.primary.default.hex}}", bold = true, bg = "{{colors.surface.default.hex}}" }
-inactive = { fg = "{{colors.secondary.default.hex}}", bg = "{{colors.surface.default.hex}}" }
-sep_inner = { open = "[", close = "]" }
-
-# : ]]]
-
-
-# : Completion [[[
-
-[completion]
-border = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.on_primary.default.hex}}" }
-
-# : ]]]
-
-
-# : Tasks [[[
-
-[tasks]
-border = { fg = "{{colors.primary.default.hex}}" }
-title = {}
-hovered = { fg = "{{colors.tertiary_fixed.default.hex}}", underline = true }
+# Progress
+progress_label  = { bold = true }
+progress_normal = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.surface_bright.default.hex}}" }
+progress_error  = { fg = "{{colors.error.default.hex}}", bg = "{{colors.surface_bright.default.hex}}" }
 
 # : ]]]
 
@@ -124,22 +96,59 @@ separator_style = { fg = "{{colors.on_surface.default.hex}}" }
 # : ]]]
 
 
-# : Help [[[
+# : Notify [[[
 
-[help]
-on = { fg = "{{colors.on_surface.default.hex}}" }
-run = { fg = "{{colors.on_surface.default.hex}}" }
-footer = { fg = "{{colors.on_secondary.default.hex}}", bg = "{{colors.secondary.default.hex}}" }
+[notify]
+title_info  = { fg = "{{colors.tertiary.default.hex}}" }
+title_warn  = { fg = "{{colors.primary.default.hex}}" }
+title_error = { fg = "{{colors.error.default.hex}}" }
 
 # : ]]]
 
 
-# : Notify [[[
+# : Picker [[[
 
-[notify]
-title_info = { fg = "{{colors.tertiary.default.hex}}" }
-title_warn = { fg = "{{colors.primary.default.hex}}" }
-title_error = { fg = "{{colors.error.default.hex}}" }
+[pick]
+border = { fg = "{{colors.primary.default.hex}}" }
+active = { fg = "{{colors.tertiary.default.hex}}", bold = true }
+inactive = {}
+
+# : ]]]
+
+
+# : Input [[[
+
+[input]
+border = { fg = "{{colors.primary.default.hex}}" }
+value  = { fg = "{{colors.on_surface.default.hex}}" }
+
+# : ]]]
+
+
+# : Completion [[[
+
+[cmp]
+border = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.on_primary.default.hex}}" }
+
+# : ]]]
+
+
+# : Tasks [[[
+
+[tasks]
+border  = { fg = "{{colors.primary.default.hex}}" }
+title   = {}
+hovered = { fg = "{{colors.tertiary_fixed.default.hex}}", underline = true }
+
+# : ]]]
+
+
+# : Help [[[
+
+[help]
+on     = { fg = "{{colors.on_surface.default.hex}}" }
+run    = { fg = "{{colors.on_surface.default.hex}}" }
+footer = { fg = "{{colors.on_secondary.default.hex}}", bg = "{{colors.secondary.default.hex}}" }
 
 # : ]]]
 


### PR DESCRIPTION
Update config for Yazi v25.12.29 (#86)

I tried to keep the original style by @simla33, but made a few small changes:
1) Added indicator padding to match the existing style:
```
[indicator]
padding = { open = "█", close = "█" }
```
2) Changed border symbol to be more comfortable for most users:
```
border_symbol = "│"
```
3) Style fixes

The config sections were also reordered to follow the official Yazi documentation
