### PR TITLE
Better terminal-sequence hook?

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ import = ["colors.toml"]
 [templates.terminal-sequences]
 input_path = 'path/to/template'
 output_path = "~/.cache/terminal-sequences"
-post_hook = "cat ~/.cache/terminal-sequences > /dev/pts/[0-9]*" # export the sequences to every running terminal
+post_hook = "tee /dev/pts/[0-9]* < ~/.cache/terminal-sequences" # export the sequences to every running terminal
 ```
 
 The target for post_hook changes depending on your OS.


### PR DESCRIPTION
I noticed that with bash v5.3.3 I get an ambiguous redirect error with the provided terminal sequence hook.  This change works for me and might be more compatible with various version of bash?  Since the redirect operator doesn't seem to support globing on my version?