### PR TITLE
feat: add vscode matugen theme using extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [Tmux](#tmux)
 - [Zellij](#zellij)
 - [Vivaldi](#vivaldi)
+- [VS Code](#vs-code)
 - [Waybar](#waybar)
 - [WezTerm](#wezterm)
 - [Windows Terminal](#windows-terminal)
@@ -1031,6 +1032,21 @@ output_path = 'path/to/vivaldi_css/vivaldi.css'
 1. In vivaldi://experiments, enable “Allow for using CSS modifications”.
 2. In Settings > Appearance > Custom UI Modifications, select the folder where you’ll store matugen vivaldi.css output.
 Note that you can store vivaldi.css anywhere in a separate folder.
+
+### VS Code
+Install the [Matugen Theme](https://marketplace.visualstudio.com/items?itemName=haikalllp.matugen-theme) extension from the VS Code Marketplace or [Open VSX](https://open-vsx.org/) (for VSCodium).
+
+```toml
+[config]
+# ...
+[templates.vscode-raw]
+input_path = './templates/vscode-colors'
+output_path = '~/.cache/matugen/vscode-colors'
+
+[templates.vscode-json]
+input_path = './templates/vscode-colors.json'
+output_path = '~/.cache/matugen/vscode-colors.json'
+```
 
 ### Waybar
 ```toml

--- a/templates/vscode-colors
+++ b/templates/vscode-colors
@@ -1,0 +1,16 @@
+{{ colors.background.default.hex }}
+{{ colors.error.default.hex }}
+{{ colors.secondary.default.hex | saturate: 20.0, hsl }}
+{{ colors.tertiary.default.hex | saturate: 15.0, hsl }}
+{{ colors.primary.default.hex }}
+{{ colors.tertiary.default.hex }}
+{{ colors.secondary_container.default.hex | saturate: 20.0, hsl }}
+{{ colors.on_surface_variant.default.hex }}
+{{ colors.surface_variant.default.hex }}
+{{ colors.error.default.hex | auto_lightness: 10.0 }}
+{{ colors.secondary.default.hex | auto_lightness: 10.0 | saturate: 20.0, hsl }}
+{{ colors.tertiary.default.hex | auto_lightness: 10.0 | saturate: 15.0, hsl }}
+{{ colors.primary.default.hex | auto_lightness: 10.0 }}
+{{ colors.tertiary.default.hex | auto_lightness: 10.0 }}
+{{ colors.primary_container.default.hex | saturate: 10.0, hsl }}
+{{ colors.on_background.default.hex }}

--- a/templates/vscode-colors
+++ b/templates/vscode-colors
@@ -1,5 +1,5 @@
 {{ colors.background.default.hex }}
-{{ colors.error.default.hex }}
+{{ colors.on_surface.default.hex | saturate: 70.0, hsl }}
 {{ colors.secondary.default.hex | saturate: 20.0, hsl }}
 {{ colors.tertiary.default.hex | saturate: 15.0, hsl }}
 {{ colors.primary.default.hex }}
@@ -7,7 +7,7 @@
 {{ colors.secondary_container.default.hex | saturate: 20.0, hsl }}
 {{ colors.on_surface_variant.default.hex }}
 {{ colors.surface_variant.default.hex }}
-{{ colors.error.default.hex | auto_lightness: 10.0 }}
+{{ colors.surface_tint.default.hex | saturate: 15.0, hsl }}
 {{ colors.secondary.default.hex | auto_lightness: 10.0 | saturate: 20.0, hsl }}
 {{ colors.tertiary.default.hex | auto_lightness: 10.0 | saturate: 15.0, hsl }}
 {{ colors.primary.default.hex | auto_lightness: 10.0 }}

--- a/templates/vscode-colors.json
+++ b/templates/vscode-colors.json
@@ -1,0 +1,28 @@
+{
+  "checksum": ":)",
+  "wallpaper": "{{ image }}",
+  "alpha": "100",
+  "special": {
+    "background": "{{ colors.background.default.hex }}",
+    "foreground": "{{ colors.on_background.default.hex }}",
+    "cursor": "{{ colors.primary.default.hex }}"
+  },
+  "colors": {
+    "color0": "{{ colors.background.default.hex }}",
+    "color1": "{{ colors.error.default.hex }}",
+    "color2": "{{ colors.secondary.default.hex | saturate: 20.0, hsl }}",
+    "color3": "{{ colors.tertiary.default.hex | saturate: 15.0, hsl }}",
+    "color4": "{{ colors.primary.default.hex }}",
+    "color5": "{{ colors.tertiary.default.hex }}",
+    "color6": "{{ colors.secondary_container.default.hex | saturate: 20.0, hsl }}",
+    "color7": "{{ colors.on_surface_variant.default.hex }}",
+    "color8": "{{ colors.surface_variant.default.hex }}",
+    "color9": "{{ colors.error.default.hex | auto_lightness: 10.0 }}",
+    "color10": "{{ colors.secondary.default.hex | auto_lightness: 10.0 | saturate: 20.0, hsl }}",
+    "color11": "{{ colors.tertiary.default.hex | auto_lightness: 10.0 | saturate: 15.0, hsl }}",
+    "color12": "{{ colors.primary.default.hex | auto_lightness: 10.0 }}",
+    "color13": "{{ colors.tertiary.default.hex | auto_lightness: 10.0 }}",
+    "color14": "{{ colors.primary_container.default.hex | saturate: 10.0, hsl }}",
+    "color15": "{{ colors.on_background.default.hex }}"
+  }
+}

--- a/templates/vscode-colors.json
+++ b/templates/vscode-colors.json
@@ -9,7 +9,7 @@
   },
   "colors": {
     "color0": "{{ colors.background.default.hex }}",
-    "color1": "{{ colors.error.default.hex }}",
+    "color1": "{{ colors.on_surface.default.hex | saturate: 70.0, hsl }}",
     "color2": "{{ colors.secondary.default.hex | saturate: 20.0, hsl }}",
     "color3": "{{ colors.tertiary.default.hex | saturate: 15.0, hsl }}",
     "color4": "{{ colors.primary.default.hex }}",
@@ -17,7 +17,7 @@
     "color6": "{{ colors.secondary_container.default.hex | saturate: 20.0, hsl }}",
     "color7": "{{ colors.on_surface_variant.default.hex }}",
     "color8": "{{ colors.surface_variant.default.hex }}",
-    "color9": "{{ colors.error.default.hex | auto_lightness: 10.0 }}",
+    "color9": "{{ colors.surface_tint.default.hex | saturate: 15.0, hsl }}",
     "color10": "{{ colors.secondary.default.hex | auto_lightness: 10.0 | saturate: 20.0, hsl }}",
     "color11": "{{ colors.tertiary.default.hex | auto_lightness: 10.0 | saturate: 15.0, hsl }}",
     "color12": "{{ colors.primary.default.hex | auto_lightness: 10.0 }}",


### PR DESCRIPTION
# VS Code / VS Codium Theme
- Added templates:
    * `vscode-colors`
    * `vscode-colors.json`
- Update `README.md` to use the extension and setup for `config.toml`. 
- **Extension Links:**
    * Marketplace - https://marketplace.visualstudio.com/items?itemName=haikalllp.matugen-theme
    * OVSX - https://open-vsx.org/extension/haikalllp/matugen-theme
    * Github - https://github.com/haikalllp/vscode-matugen-theme

Config Example:
```bash
# VS Code Matugen Theme extension
[templates.vscode-raw]
input_path = './templates/vscode-colors'
output_path = '~/.cache/matugen/vscode-colors'

[templates.vscode-json]
input_path = './templates/vscode-colors.json'
output_path = '~/.cache/matugen/vscode-colors.json'
```

## Preview

![image1](https://github.com/user-attachments/assets/0f648de2-88b6-4b2c-885b-38f0ab909f88)
![image2](https://github.com/user-attachments/assets/8e847b42-f442-4953-8c3c-9dc618a72e7a)
![image3](https://github.com/user-attachments/assets/e3e78135-7bf6-4413-b729-e73a08e9ff53)
![image4](https://github.com/user-attachments/assets/53b5ad1f-c610-4e20-bedd-b69280494042)