### PR TITLE
Improve HeroicGamesLauncher colors on light themes

### DIFF
--- a/templates/heroic.css
+++ b/templates/heroic.css
@@ -33,7 +33,7 @@ body.matugen {
   --text-default: {{colors.on_surface.default.hex}};
   --text-title: {{colors.on_surface.default.hex}};
   --text-secondary: {{colors.on_surface_variant.default.hex}};
-  --text-tertiary: {{colors.outline.default.hex}};
+  --text-tertiary: {{colors.on_tertiary.default.hex}};
   --text-hover: {{colors.primary.default.hex}};
 
   --text-title: {{colors.on_surface.default.hex}};
@@ -48,4 +48,9 @@ body.matugen {
   --anticheat-running: var(--primary);
   --anticheat-supported: var(--success);
   --anticheat-planned: {{colors.secondary.default.hex}};
+
+  --neutral-06: {{colors.on_surface_variant.default.hex}};
+  --gamecard-title-color: {{colors.surface_container.default.hex}}cc;
+  --secondary-button: var(--accent);
+  --tertiary-button: var(--primary);
 }


### PR DESCRIPTION
Added a color for the settings icon on the game covers, used to be hard-coded (used heroic's default) and too light for light themes. Also improve contrast on some texts.

Before:
<img width="1020" height="489" alt="Screenshot from 2026-05-06 21-04-57" src="https://github.com/user-attachments/assets/6a251c0c-d6b0-4ecd-bc15-9e0712838a85" />

After:
<img width="1020" height="489" alt="Screenshot from 2026-05-06 21-03-58" src="https://github.com/user-attachments/assets/18b0e233-73d2-4ab9-8b55-0913602f900c" />

I also tested it with a dark theme to make sure that everything's legible.
<img width="1020" height="489" alt="Screenshot from 2026-05-06 21-07-29" src="https://github.com/user-attachments/assets/097ae99e-aea3-4774-8556-2a47ce565f87" />
