### PR TITLE
fix: rename `name` to `url`for filetype rules

### DIFF
--- a/templates/yazi-theme.toml
+++ b/templates/yazi-theme.toml
@@ -171,8 +171,8 @@ rules = [
     { mime = "application/{pdf,doc,rtf}", fg = "#a6e3a1" },
 
     # Special files
-    { name = "*", is = "orphan", bg = "{{colors.error_container.default.hex}}" },
-    { name = "*", is = "exec", fg = "{{colors.on_error_container.default.hex}}" },
+    { url = "*", is = "orphan", bg = "{{colors.error_container.default.hex}}" },
+    { url = "*", is = "exec", fg = "{{colors.on_error_container.default.hex}}" },
 
     # Fallback
     { url = "*", fg = "{{colors.on_surface.default.hex}}" },


### PR DESCRIPTION
As stated in yazi [v25.12.29](https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#changed-1) via https://github.com/sxyazi/yazi/pull/3034