### PR TITLE
feat(kitty-colors): improve ANSI color mapping and add 256-color support

### DIFF
--- a/templates/kitty-colors.conf
+++ b/templates/kitty-colors.conf
@@ -1,49 +1,71 @@
-cursor            {{ colors.primary.dark.hex }}
-cursor_text_color {{ colors.on_primary.dark.hex }}
+# --- Main Colors ---
+background            {{ colors.surface.default.hex }}
+foreground            {{ colors.on_surface.default.hex }}
+cursor                {{ colors.on_surface.default.hex }}
+cursor_text_color     {{ colors.surface.default.hex }}
 
-foreground            {{ colors.on_surface.dark.hex }}
-background            {{ colors.surface_container_lowest.dark.hex }}
-selection_foreground  {{ colors.on_secondary.dark.hex }}
-selection_background  {{ colors.secondary.dark.hex }}
-url_color             {{ colors.secondary.dark.hex }}
+selection_background  {{ colors.secondary_container.default.hex }}
+selection_foreground  {{ colors.on_secondary_container.default.hex }}
 
-#: black 000000 767676
-color0  {{ colors.surface.dark.hex }}
-color8  {{ colors.surface_container_highest.dark.hex }}
-#: red cc0403 f2201f
-color1  {{ base16.base08.dark.hex | lighten: -20.0 }}
-color9  {{ base16.base08.dark.hex | lighten: 10.0 }}
-#: green 19cb00 23fd00
-color2  {{ colors.secondary_fixed_dim.dark.hex }}
-color10 {{ colors.secondary_fixed.dark.hex }}
-#: yellow cecb00 fffd00
-color3  {{ colors.tertiary_fixed_dim.dark.hex }}
-color11 {{ colors.tertiary_fixed.dark.hex }}
-#: blue 0d73cc 1a8fff
-color4  {{ colors.on_primary_fixed_variant.dark.hex }}
-color12 {{ colors.primary.dark.hex }}
-#: magenta cb1ed1 fd28ff
-color5  {{ colors.on_secondary_fixed_variant.dark.hex }}
-color13 {{ colors.secondary.dark.hex }}
-#: cyan 0dcdcd 14ffff
-color6  {{ colors.on_tertiary_fixed_variant.dark.hex }}
-color14 {{ colors.tertiary.dark.hex }}
-#: white dddddd ffffff
-color7  {{ colors.on_surface_variant.dark.hex }}
-color15 {{ colors.on_surface.dark.hex }}
+url_color             {{ colors.tertiary.default.hex }}
 
-mark1_foreground {{ colors.on_primary_fixed.dark.hex }}
-mark1_background {{ colors.primary_fixed.dark.hex }}
-mark2_foreground {{ colors.on_secondary_fixed.dark.hex }}
-mark2_background {{ colors.secondary_fixed.dark.hex }}
-mark3_foreground {{ colors.on_tertiary_fixed.dark.hex }}
-mark3_background {{ colors.tertiary_fixed.dark.hex }}
+# --- ANSI Colors ---
+color0                {{ colors.surface.default.hex }}
+color1                {{ colors.error.default.hex }}
+color2                {{ colors.tertiary.default.hex }}
+color3                {{ colors.secondary.default.hex }}
+color4                {{ colors.primary.default.hex }}
+color5                {{ colors.tertiary_fixed_dim.default.hex }}
+color6                {{ colors.secondary_fixed_dim.default.hex }}
+color7                {{ colors.on_surface.default.hex }}
 
-active_tab_foreground {{ colors.on_primary.dark.hex }}
-active_tab_background {{ colors.primary.dark.hex }}
-inactive_tab_foreground {{ colors.on_primary_container.dark.hex }}
-inactive_tab_background {{ colors.primary_container.dark.hex }}
+color8                {{ colors.surface_variant.default.hex }}
+color9                {{ colors.error_container.default.hex }}
+color10               {{ colors.tertiary_container.default.hex }}
+color11               {{ colors.secondary_container.default.hex }}
+color12               {{ colors.primary_container.default.hex }}
+color13               {{ colors.on_secondary_fixed_variant.default.hex }}
+color14               {{ colors.on_tertiary_fixed_variant.default.hex }}
+color15               {{ colors.on_surface_variant.default.hex }}
 
-active_border_color {{ colors.primary.dark.hex }}
-inactive_border_color {{ colors.on_primary.dark.hex }}
-# bell_border_color #ff5a00
+# --- Starship Prompt Bubbles ---
+color255              {{ colors.primary_container.default.hex }}
+color254              {{ colors.primary.default.hex }}
+color253              {{ colors.secondary_container.default.hex }}
+color252              {{ colors.secondary.default.hex }}
+color251              {{ colors.tertiary_container.default.hex }}
+color250              {{ colors.tertiary.default.hex }}
+color249              {{ colors.error_container.default.hex }}
+color248              {{ colors.error.default.hex }}
+
+color232              {{ colors.on_primary_container.default.hex }}
+color233              {{ colors.on_primary.default.hex }}
+color234              {{ colors.on_secondary_container.default.hex }}
+color235              {{ colors.on_secondary.default.hex }}
+color236              {{ colors.on_tertiary_container.default.hex }}
+color237              {{ colors.on_tertiary.default.hex }}
+color238              {{ colors.on_error_container.default.hex }}
+color239              {{ colors.on_error.default.hex }}
+color240              {{ colors.on_primary_container.default.hex }}
+
+# Matched with unthemed light/dark
+color243              {{ colors.primary.default.hex }}
+color244              {{ colors.error.default.hex }}
+color245              {{ colors.outline_variant.default.hex }}
+
+# --- UI Elements ---
+active_tab_foreground   {{ colors.on_primary.default.hex }}
+active_tab_background   {{ colors.primary.default.hex }}
+inactive_tab_foreground {{ colors.on_primary_container.default.hex }}
+inactive_tab_background {{ colors.primary_container.default.hex }}
+
+active_border_color     {{ colors.primary.default.hex }}
+inactive_border_color   {{ colors.outline.default.hex }}
+
+# --- Marks ---
+mark1_foreground        {{ colors.on_primary_fixed.default.hex }}
+mark1_background        {{ colors.primary_fixed.default.hex }}
+mark2_foreground        {{ colors.on_secondary_fixed.default.hex }}
+mark2_background        {{ colors.secondary_fixed.default.hex }}
+mark3_foreground        {{ colors.on_tertiary_fixed.default.hex }}
+mark3_background        {{ colors.tertiary_fixed.default.hex }}


### PR DESCRIPTION
This update improves the semantic mapping of ANSI colors to Material roles (e.g., mapping `error` to Red and `primary` to Blue) for better accuracy. It also adds support for the extended 256-color palette (slots 232-255) to support high-fidelity prompt themes like Starship, and fixes cursor readability issues by defining `cursor_text_color`.

updated version:
<img width="1920" height="1046" alt="updated-kitty-colors" src="https://github.com/user-attachments/assets/0d44b4b3-42eb-439f-a394-bef1e03236bf" />

previous version:
<img width="1920" height="1044" alt="previous-kitty-colors" src="https://github.com/user-attachments/assets/a372584e-a129-4f4c-931a-eccacb3b304a" />

