### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 - [SwayNC](#swaync)
 - [Steam](#steam)
 - [OBS](#obs)
+- [Obsidian](#obsidian)
 - [Telegram](#telegram)
 
 ### Alacritty


### PR DESCRIPTION
Fixed Obsidian being missing from the "List of all templates" section.