### PR TITLE
Support for Niri "Recent windows" menu.

### DIFF
--- a/templates/niri-colors.kdl
+++ b/templates/niri-colors.kdl
@@ -31,3 +31,10 @@ layout {
 overview {
 	backdrop-color "{{colors.background.default.hex}}"
 }
+
+recent-windows {
+    highlight {
+        active-color "{{colors.primary.default.hex}}"
+        urgent-color "{{colors.error.default.hex}}"
+    }
+}


### PR DESCRIPTION
<img width="1600" height="900" alt="recent-windows" src="https://github.com/user-attachments/assets/7f9d9f5e-e60c-48da-8001-ba3300643555" />
Adapted niri-colors.kdl to support new "Recent windows" feature.