### PR TITLE
fix: make papirus-folders doesnt block

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ colors_to_compare = [
     { name = "yellow",     color = "#f9bd30" },
 ]
 compare_to = "{{ colors.primary.default.hex }}"
-post_hook = 'sudo -n papirus-folders -C {{ closest_color }} -u'
+post_hook = 'nohup sudo -n papirus-folders -C {{ closest_color }} -u > /dev/null 2>&1 &'
 index = 1
 # ...
 ```


### PR DESCRIPTION
Follow up fix for - https://github.com/InioX/matugen-themes/pull/143
Make sure the papirus-folders posthook doesnt block stdout and make sure it runs in background.